### PR TITLE
Add matching title as the -t option

### DIFF
--- a/jumpapp
+++ b/jumpapp
@@ -16,6 +16,7 @@ Options:
         (see Argument Passthrough in man page)
   -c NAME -- find window using NAME as WM_CLASS (instead of COMMAND)
   -i NAME -- find process using NAME as the command name (instead of COMMAND)"
+  -t NAME -- process window has to have NAME as the window title
 }
 
 main() {
@@ -32,6 +33,7 @@ main() {
             n) fork='' ;;
             p) passthrough=1; force=1 ;; # passthrough implies force
             r) in_reverse=1 ;;
+            t) matching_title="$OPTARG" ;;
         esac
     done
     shift $(( OPTIND - 1 ))
@@ -239,7 +241,9 @@ list_pids_for_command_from_procfs() {
 list_windows() {
     local windowid desktop pid wm_class hostname title
     while read -r windowid desktop pid wm_class hostname title; do
+    if [[ "$matching_title" == '' || "$title" =~ "$matching_title" ]]; then
         printf '%s\n' "$windowid $hostname $pid $desktop ${wm_class##*.} $title"
+    fi
     done < <(wmctrl -lpx)
 }
 

--- a/jumpapp
+++ b/jumpapp
@@ -77,7 +77,7 @@ jumpapp() {
         activate_window "$(get_subsequent_window "${windowids[@]}")" ||
             die "Error: unable to focus window for '$cmdid'"
     else
-        if (( ${#pids[@]} )) && [[ -z "$force" ]]; then
+        if [[ -z "$matching_title" ]] && (( ${#pids[@]} )) && [[ -z "$force" ]]; then
             die "Error: found running process for '$cmdid', but found no window to jump to"
         else
             launch_command "$@"

--- a/jumpapp
+++ b/jumpapp
@@ -23,7 +23,7 @@ main() {
     local classid cmdid force fork=1 list passthrough='' in_reverse=''
 
     local OPTIND
-    while getopts c:fhi:Lnpr opt; do
+    while getopts c:fhi:Lnprt: opt; do
         case "$opt" in
             c) classid="$OPTARG" ;;
             f) force=1 ;;


### PR DESCRIPTION
Use case:
I use Chromium feature to open Gmail webpage as an application window. Then I bind a hotkey to focus directly the Gmail window (and not other Chromium windows) or open it if it's closed:
`jumpapp -t "Mail" chromium-browser --app=https://mail.google.com/mail/u/0`

Then I bind another hotkey to cycle other Chromium windows or open Chromium if it's closed:
`jumpapp -t Chromium chromium-browser --ssl-version-min=tls1`


I use this feature a lot since months so I though you might want to make it accessible for everyone.