### PR TITLE
Added the 'match last focused window' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ In short, **jumpapp** is probably the fastest way for a keyboard-junkie to switc
       -c NAME -- find window using NAME as WM_CLASS (instead of COMMAND)
       -i NAME -- find process using NAME as the command name (instead of COMMAND)
       -w -- only find the applications in the current workspace
+      -g -- switch to the last focused window when dealing with multiple matching windows
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ In short, **jumpapp** is probably the fastest way for a keyboard-junkie to switc
       -c NAME -- find window using NAME as WM_CLASS (instead of COMMAND)
       -i NAME -- find process using NAME as the command name (instead of COMMAND)
       -w -- only find the applications in the current workspace
-      -g -- switch to the last focused window when dealing with multiple matching windows
 
 ## Installation
 

--- a/jumpapp
+++ b/jumpapp
@@ -21,7 +21,7 @@ Options:
 }
 
 main() {
-    local classid cmdid force fork=1 list passthrough in_reverse matching_title workspace_filter match_last_focused_window
+    local classid cmdid force fork=1 list passthrough in_reverse matching_title workspace_filter
 
     local OPTIND
     while getopts c:fhi:Lnprt:w opt; do

--- a/jumpapp
+++ b/jumpapp
@@ -17,14 +17,15 @@ Options:
   -t NAME -- process window has to have NAME as the window title
   -c NAME -- find window using NAME as WM_CLASS (instead of COMMAND)
   -i NAME -- find process using NAME as the command name (instead of COMMAND)
-  -w -- only find the applications in the current workspace"
+  -w -- only find the applications in the current workspace
+  -g -- switch to the last focused window when dealing with multiple matching windows"
 }
 
 main() {
-    local classid cmdid force fork=1 list passthrough in_reverse matching_title workspace_filter
+    local classid cmdid force fork=1 list passthrough in_reverse matching_title workspace_filter match_last_focused_window
 
     local OPTIND
-    while getopts c:fhi:Lnprt:w opt; do
+    while getopts c:fhi:Lnprt:wg opt; do
         case "$opt" in
             c) classid="$OPTARG" ;;
             f) force=1 ;;
@@ -36,6 +37,7 @@ main() {
             r) in_reverse=1 ;;
             t) matching_title="$OPTARG"; force=1 ;;
             w) workspace_filter="$(get_active_workspace)"; force=1 ;;
+            g) match_last_focused_window=1 ;;
         esac
     done
     shift $(( OPTIND - 1 ))
@@ -164,9 +166,11 @@ print_windows() {
 }
 
 get_subsequent_window() {
-    if [[ -n "$in_reverse" ]]; then
+    if [[ -n $in_reverse ]]; then
         get_prev_window "$@"
-    else
+	elif [[ -n $match_last_focused_window ]]; then
+        get_last_focused_window "$@"
+	else
         get_next_window "$@"
     fi
 }
@@ -184,6 +188,41 @@ get_prev_window() {
         done
 
         printf '%s\n' "$prev"
+    fi
+}
+
+get_last_focused_window() {
+    local matched_windows=($@)
+    local recent_windows=($(xprop -root | grep "^_NET_CLIENT_LIST_STACKING" | cut -d '#' -f2- | tr ',' ' '))
+    local active_window=$(get_active_windowid)
+    local recent_window
+
+    for ((i=${#recent_windows[@]}-1; i>=0; i--)) do
+
+        recent_window=${recent_windows[i]}
+        if are_numbers_equal $recent_window $active_window; then
+            continue
+        fi
+
+        for matched_window in ${matched_windows[@]}; do
+            if are_numbers_equal $recent_window $matched_window; then
+                printf '%s\n' $matched_window
+                return
+            fi
+        done
+    done
+
+    get_next_window "$@"
+}
+
+are_numbers_equal() {
+    local success=0
+    local failure=1
+
+    if [[ $(($1)) == $(($2)) ]]; then
+        return $success
+    else
+        return $failure
     fi
 }
 

--- a/jumpapp
+++ b/jumpapp
@@ -17,15 +17,14 @@ Options:
   -t NAME -- process window has to have NAME as the window title
   -c NAME -- find window using NAME as WM_CLASS (instead of COMMAND)
   -i NAME -- find process using NAME as the command name (instead of COMMAND)
-  -w -- only find the applications in the current workspace
-  -g -- switch to the last focused window when dealing with multiple matching windows"
+  -w -- only find the applications in the current workspace"
 }
 
 main() {
     local classid cmdid force fork=1 list passthrough in_reverse matching_title workspace_filter match_last_focused_window
 
     local OPTIND
-    while getopts c:fhi:Lnprt:wg opt; do
+    while getopts c:fhi:Lnprt:w opt; do
         case "$opt" in
             c) classid="$OPTARG" ;;
             f) force=1 ;;
@@ -37,7 +36,6 @@ main() {
             r) in_reverse=1 ;;
             t) matching_title="$OPTARG"; force=1 ;;
             w) workspace_filter="$(get_active_workspace)"; force=1 ;;
-            g) match_last_focused_window=1 ;;
         esac
     done
     shift $(( OPTIND - 1 ))
@@ -167,12 +165,70 @@ print_windows() {
 
 get_subsequent_window() {
     if [[ -n $in_reverse ]]; then
-        get_prev_window "$@"
-	elif [[ -n $match_last_focused_window ]]; then
-        get_last_focused_window "$@"
+        get_oldest_focused_window "$@"
 	else
-        get_next_window "$@"
+        get_most_recently_focused_window "$@"
     fi
+}
+
+get_oldest_focused_window() {
+    local unordered_windows=($@)
+    local windows_in_stacking_order=($(list_stacking_order))
+    local active_window=$(get_active_windowid)
+
+    for window in ${windows_in_stacking_order[@]}; do
+        if numerically_equal $window $active_window; then
+            continue
+        fi
+
+        get_matching_window_from_list $window ${unordered_windows[@]}
+    done
+
+    get_prev_window "$@"
+}
+
+get_most_recently_focused_window() {
+    local unordered_windows=($@)
+    local windows_in_stacking_order=($(list_stacking_order | reverse_words))
+    local active_window=$(get_active_windowid)
+
+    for window in ${windows_in_stacking_order[@]}; do
+        if numerically_equal $window $active_window; then
+            continue
+        fi
+
+        get_matching_window_from_list $window ${unordered_windows[@]}
+    done
+
+    get_next_window "$@"
+}
+
+get_matching_window_from_list() {
+    local window_to_search_for=$1
+    local window_list=${@:2}
+
+    for window in ${window_list[@]}; do
+        if numerically_equal $window_to_search_for $window; then
+            printf '%s\n' $window
+            return
+        fi
+    done
+}
+
+numerically_equal() {
+    if [[ $(($1)) == $(($2)) ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+list_stacking_order() {
+    xprop -root | grep '^_NET_CLIENT_LIST_STACKING' | cut -d '#' -f2- | tr ',' ' '
+}
+
+reverse_words() {
+    awk '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }'
 }
 
 get_prev_window() {
@@ -188,41 +244,6 @@ get_prev_window() {
         done
 
         printf '%s\n' "$prev"
-    fi
-}
-
-get_last_focused_window() {
-    local matched_windows=($@)
-    local recent_windows=($(xprop -root | grep "^_NET_CLIENT_LIST_STACKING" | cut -d '#' -f2- | tr ',' ' '))
-    local active_window=$(get_active_windowid)
-    local recent_window
-
-    for ((i=${#recent_windows[@]}-1; i>=0; i--)) do
-
-        recent_window=${recent_windows[i]}
-        if are_numbers_equal $recent_window $active_window; then
-            continue
-        fi
-
-        for matched_window in ${matched_windows[@]}; do
-            if are_numbers_equal $recent_window $matched_window; then
-                printf '%s\n' $matched_window
-                return
-            fi
-        done
-    done
-
-    get_next_window "$@"
-}
-
-are_numbers_equal() {
-    local success=0
-    local failure=1
-
-    if [[ $(($1)) == $(($2)) ]]; then
-        return $success
-    else
-        return $failure
     fi
 }
 

--- a/jumpapp
+++ b/jumpapp
@@ -166,8 +166,10 @@ print_windows() {
 get_subsequent_window() {
     if [[ -n $in_reverse ]]; then
         get_oldest_focused_window "$@"
+        get_prev_window "$@"
 	else
         get_most_recently_focused_window "$@"
+        get_next_window "$@"
     fi
 }
 
@@ -183,8 +185,6 @@ get_oldest_focused_window() {
 
         get_matching_window_from_list $window ${unordered_windows[@]}
     done
-
-    get_prev_window "$@"
 }
 
 get_most_recently_focused_window() {
@@ -199,8 +199,6 @@ get_most_recently_focused_window() {
 
         get_matching_window_from_list $window ${unordered_windows[@]}
     done
-
-    get_next_window "$@"
 }
 
 get_matching_window_from_list() {

--- a/t/test_jumpapp
+++ b/t/test_jumpapp
@@ -4,6 +4,7 @@ setUp() {
     active_windowid=0
     get_window_types_output=_NET_WM_WINDOW_TYPE_NORMAL
     list_pids_for_command_output=
+    list_stacking_order_output=
 
     has_command_val=0
 
@@ -286,6 +287,55 @@ it_prints_matching_windows_when_called_with_-L() {
     [[ "$output" == *"678 somehost 123 -1 someapp: SomeApp Window #2"* ]] || fail 'Output does not list Window #2'
 }
 
+it_reverses_words() {
+    local output=$(echo dog lazy the over jumps fox brown quick The | reverse_words)
+    assertEquals 'Reverse_words needs to produce a phrase "The quick brown fox jumps over the lazy dog"' \
+                 'The quick brown fox jumps over the lazy dog' "$output"
+}
+
+it_compares_hexes_numerically() {
+    numerically_equal "0x0000f" "0xf"
+    assertTrue '0x0000f should be the same as 0xf (numerically)' $?
+
+    numerically_equal "0xdeadbeef" "0xff"
+    assertFalse '0xdeadbeef should NOT be the same as 0xf (numerically)' $?
+}
+
+it_gets_the_matching_window_id_from_list() {
+    local window_to_search_for=0x00eface
+    local window_list=(0x1200003 0x5000001 0x4200045 0x1000004 0x3200041 0x460017f 0x460017c 0x32064c5 0x400004 0xeface)
+
+    local output=$(get_matching_window_from_list ${window_to_search_for} ${window_list[@]})
+    assertEquals 'A matching window id that is numerically equal to "0x00eface" needs to be found in the provided window id list' \
+                 '0xeface' ${output}
+}
+
+it_gets_the_matching_window_id_from_list_with_no_result() {
+    local window_to_search_for=0xdeadbeef
+    local window_list=(0x1200003 0x5000001 0x4200045 0x1000004 0x3200041 0x460017f 0x460017c 0x32064c5 0x400004 0xe00004)
+
+    assertNull 'get_matching_window_from_list should NOT have found a window id called "0xdeadbeef" in the list' \
+               "$(get_matching_window_from_list ${window_to_search_for} ${window_list[@]})"
+}
+
+it_gets_most_recently_focused_windows_in_order() {
+    local matched_unordered_windows='0x0bad 0x0c0de 0x0d00d'
+    local expected_order=$(printf '%s\n%s\n%s\n' 0x0c0de 0x0d00d 0x0bad)
+    list_stacking_order_output='0x1200003 0xbad 0xd00d 0x1000004 0xc0de 0x460017f 0x460017c 0x32064c5 0x400004 0xe00004'
+
+    assertEquals 'Orders matched windows by when the window was last focused (most recent focused windows)' \
+                 "${expected_order}" "$(get_most_recently_focused_window ${matched_unordered_windows})"
+}
+
+it_gets_oldest_focused_windows_in_order() {
+    local matched_unordered_windows='0x0bad 0x0c0de 0x0d00d'
+    local expected_order=$(printf '%s\n%s\n%s\n' 0x0bad 0x0d00d 0x0c0de)
+    list_stacking_order_output='0x1200003 0xbad 0xd00d 0x1000004 0xc0de 0x460017f 0x460017c 0x32064c5 0x400004 0xe00004'
+
+    assertEquals 'Orders matched windows by when the window was first focused (oldest focused windows)' \
+                 "${expected_order}" "$(get_oldest_focused_window ${matched_unordered_windows})"
+}
+
 ##### Test Doubles #####
 
 source ./jumpapp # load app now, so we can override it
@@ -342,6 +392,9 @@ die() {
     return 1
 }
 
+list_stacking_order() {
+    echo ${list_stacking_order_output}
+}
 
 ##### Test Harness #####
 


### PR DESCRIPTION
I have the following use-case:
1) Open multiple windows of the same application (for example: 5 chrome windows)
2) Open some other application
3) Now try to get back to the relevant chrome window (which was focused previously).

As there is no way to tell jumpapp that the previously focused window is more important you sometimes end up cycling through all of the windows before getting the one that is actually relevant. You can obviously go in reverse, but that doesn't really help all that much.

I added a flag that will force jumpapp to prioritize previously focused windows.