### PR TITLE
fixed issue where stacking size reached more than 9 windows

### DIFF
--- a/jumpapp
+++ b/jumpapp
@@ -228,7 +228,7 @@ get_matching_window_from_list() {
 reverse_words() {
     local i words
     IFS=' ' read -ra words
-    for ((i=${#words}; i>=0; i--)); do
+    for ((i=${#words[@]}; i>=0; i--)); do
         printf '%s ' "${words[i]}"
     done
 }


### PR DESCRIPTION
- i got odd issue, that I couldn't explain. If we use array which is
longer than 9 elems, than using simple: ${#array}, will return 9 as
length, but ${#array[@]} will return proper size