### PR TITLE
add -R option: keep workspace when raising an app

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ In short, **jumpapp** is probably the fastest way for a keyboard-junkie to switc
       -c NAME -- find window using NAME as WM_CLASS (instead of COMMAND)
       -i NAME -- find process using NAME as the command name (instead of COMMAND)
       -w -- only find the applications in the current workspace
+      -R -- bring the application to the current workspace when raising
+            (the default behaviour is to switch to the workspace that the
+            application is currently on)
       -C -- center cursor when raising application
 
 ## Installation

--- a/jumpapp
+++ b/jumpapp
@@ -18,6 +18,9 @@ Options:
   -c NAME -- find window using NAME as WM_CLASS (instead of COMMAND)
   -i NAME -- find process using NAME as the command name (instead of COMMAND)
   -w -- only find the applications in the current workspace
+  -R -- bring the application to the current workspace when raising
+        (the default behaviour is to switch to the workspace that the
+        application is currently on)
   -C -- center cursor when raising application"
 }
 
@@ -25,7 +28,7 @@ main() {
     local classid cmdid force fork=1 list passthrough in_reverse matching_title workspace_filter mouse_center
 
     local OPTIND
-    while getopts c:fhi:Lnprt:wC opt; do
+    while getopts c:fhi:Lnprt:wRC opt; do
         case "$opt" in
             c) classid="$OPTARG" ;;
             f) force=1 ;;
@@ -37,6 +40,7 @@ main() {
             r) in_reverse=1 ;;
             t) matching_title="$OPTARG"; force=1 ;;
             w) workspace_filter="$(get_active_workspace)"; force=1 ;;
+            R) keep_workspace=1 ;;
             C) mouse_center=1 ;;
         esac
     done
@@ -373,7 +377,11 @@ get_active_workspace() {
 }
 
 activate_window() {
-    wmctrl -i -a "$1"
+    if [[ -n "$keep_workspace" ]]; then
+        wmctrl -i -R "$1"
+    else
+        wmctrl -i -a "$1"
+    fi
 }
 
 center_cursor() {

--- a/jumpapp
+++ b/jumpapp
@@ -87,8 +87,13 @@ jumpapp() {
       list_matching_windows "$classid" "${pids[@]}" | print_windows
     elif (( ${#windowids[@]} )) && ! needs_passthrough "$@"; then
         local window=$(get_subsequent_window "${windowids[@]}")
-        activate_window "$window" ||
-            die "Error: unable to focus window for '$cmdid'"
+        if [[ -n "$keep_workspace" ]]; then
+            keep_workspace_activate_window "$window" ||
+                die "Error: unable to focus window for '$cmdid'"
+        else
+            change_workspace_activate_window "$window" ||
+                die "Error: unable to focus window for '$cmdid'"
+        fi
 
         if [[ -n "$mouse_center" ]]; then
             center_cursor "$window"
@@ -376,12 +381,12 @@ get_active_workspace() {
     done < <(wmctrl -d)
 }
 
-activate_window() {
-    if [[ -n "$keep_workspace" ]]; then
-        wmctrl -i -R "$1"
-    else
-        wmctrl -i -a "$1"
-    fi
+change_workspace_activate_window() {
+    wmctrl -i -a "$1"
+}
+
+keep_workspace_activate_window() {
+    wmctrl -i -R "$1"
 }
 
 center_cursor() {

--- a/t/test_jumpapp
+++ b/t/test_jumpapp
@@ -8,6 +8,7 @@ setUp() {
 
     has_command_val=0
 
+    keep_workspace_activate_window_called=
     activate_window_called=
     activate_window_arg=
     center_cursor_called=
@@ -80,6 +81,17 @@ it_calls_activate_window_when_window_found_by_pid() {
     main someapp
 
     assertNotNull 'activate_window() called' "$activate_window_called"
+    assertEquals 456 "$activate_window_arg"
+    assertNull 'fork_command() not called' "$fork_command_called"
+}
+
+it_calls_keep_workspace_activate_window_when_-R_is_passed() {
+    list_pids_for_command_output='123'
+    list_windows_output='456 somehost 123 -1 some-class'
+
+    main -R someapp
+
+    assertNotNull 'keep_workspace_activate_window() called' "$keep_workspace_activate_window_called"
     assertEquals 456 "$activate_window_arg"
     assertNull 'fork_command() not called' "$fork_command_called"
 }
@@ -375,7 +387,14 @@ get_active_workspace() {
     printf '%s\n' "$active_workspace"
 }
 
-activate_window() {
+change_workspace_activate_window() {
+    activate_window_called=1
+    activate_window_arg=$1
+    return 0
+}
+
+keep_workspace_activate_window() {
+    keep_workspace_activate_window_called=1
     activate_window_called=1
     activate_window_arg=$1
     return 0


### PR DESCRIPTION
Bring the application to the current workspace when raising.
The default behaviour (when `-R` is not specified) is to switch to the workspace that the application is currently on and then focus the window.
Specifying `-R` moves the window to the current workspace and then focuses it.
See `-a` and `-R` in `man wmctrl`.

(N.B. I'm not sure if this should have any tests?)