### PR TITLE
Invert window type match

### DIFF
--- a/jumpapp
+++ b/jumpapp
@@ -166,8 +166,21 @@ where_class_or_pid_matches() {
 where_normal_window() {
     local windowid rest
     while read -r windowid rest; do
-        case "$(get_window_types "$windowid")" in
-            '' | *_NET_WM_WINDOW_TYPE_NORMAL* | *_NET_WM_WINDOW_TYPE_DIALOG*)
+        case "$(get_window_types "$windowid")" in \
+            *_NET_WM_WINDOW_TYPE_DESKTOP* |       \
+            *_NET_WM_WINDOW_TYPE_DOCK* |          \
+            *_NET_WM_WINDOW_TYPE_TOOLBAR* |       \
+            *_NET_WM_WINDOW_TYPE_MENU* |          \
+            *_NET_WM_WINDOW_TYPE_UTILITY* |       \
+            *_NET_WM_WINDOW_TYPE_SPLASH* |        \
+            *_NET_WM_WINDOW_TYPE_DROPDOWN_MENU* | \
+            *_NET_WM_WINDOW_TYPE_POPUP_MENU* |    \
+            *_NET_WM_WINDOW_TYPE_TOOLTIP* |       \
+            *_NET_WM_WINDOW_TYPE_NOTIFICATION* |  \
+            *_NET_WM_WINDOW_TYPE_COMBO* |         \
+            *_NET_WM_WINDOW_TYPE_DND*)
+                ;;
+            *)
                 printf '%s\n' "$windowid $rest"
                 ;;
         esac

--- a/t/test_jumpapp
+++ b/t/test_jumpapp
@@ -284,14 +284,47 @@ it_calls_activate_window_with_windowid_where_workspace_is_-1_when_-w_passed() {
     assertEquals 567 "$activate_window_arg"
 }
 
-it_throws_an_error_when_process_is_running_but_window_type_is_not_normal() {
+it_throws_an_error_when_process_is_running_but_all_window_type_are_known_not_normal_windows() {
     list_pids_for_command_output='123'
     list_windows_output='456 somehost 123 -1 someapp'
-    get_window_types_output=_NET_WM_WINDOW_TYPE_DESKTOP
+    get_window_types_output='_NET_WM_WINDOW_TYPE_DESKTOP, _NET_WM_WINDOW_TYPE_DOCK, _NET_WM_WINDOW_TYPE_TOOLBAR'
 
     main someapp >/dev/null
 
     assertNotNull 'die() called' "$die_called"
+}
+
+it_calls_activate_window_when_get_window_types_returns_normal_window() {
+    get_window_types_output='_NET_WM_WINDOW_TYPE_NORMAL'
+    list_pids_for_command_output='123'
+    list_windows_output='456 somehost 123 -1 some-class'
+
+    main someapp
+
+    assertNotNull 'activate_window() called' "$activate_window_called"
+    assertEquals 456 "$activate_window_arg"
+}
+
+it_calls_activate_window_when_get_window_types_returns_dialog_window() {
+    get_window_types_output='_NET_WM_WINDOW_TYPE_NORMAL'
+    list_pids_for_command_output='123'
+    list_windows_output='456 somehost 123 -1 some-class'
+
+    main someapp
+
+    assertNotNull 'activate_window() called' "$activate_window_called"
+    assertEquals 456 "$activate_window_arg"
+}
+
+it_calls_activate_window_when_get_window_types_returns_unknown_window_type() {
+    get_window_types_output='_NET_WM_WINDOW_TYPE_DERP'
+    list_pids_for_command_output='123'
+    list_windows_output='456 somehost 123 -1 some-class'
+
+    main someapp
+
+    assertNotNull 'activate_window() called' "$activate_window_called"
+    assertEquals 456 "$activate_window_arg"
 }
 
 it_calls_activate_window_when_get_window_types_returns_multiple_entires() {


### PR DESCRIPTION
Implements https://github.com/mkropat/jumpapp/issues/42#issuecomment-500132745

The idea behind this change is that when looking at window types, we no longer look for known good values, instead we look for the absence of known bad values. This has the effect of allowing unknown values, coming from applications such as Slack.

It is conceivable an unintended consequence of this change is that windows that are not matched today (and we don't want to match them), will start to be matched after this change. It's unclear to me if this will actually be an issue, so I am inclined to release the change and deal with any issues that come up.