### PR TITLE
make app switching faster by using procfs rather than pgrep

### DIFF
--- a/jumpapp
+++ b/jumpapp
@@ -338,18 +338,6 @@ equals_case_insensitive() {
 #     confusingly include all arguments in argv[0] (I'm looking at you
 #     chromium-browser).
 list_pids_for_command() {
-    if has_command pgrep; then
-        list_pids_for_command_with_pgrep "$@"
-    else
-        list_pids_for_command_from_procfs "$@"
-    fi
-}
-
-list_pids_for_command_with_pgrep() {
-    pgrep -f "^(/.*/)?$1\b"
-}
-
-list_pids_for_command_from_procfs() {
     local cmd_argv0
     for path in /proc/*/cmdline; do
         read -rd '' cmd_argv0 <"$path"


### PR DESCRIPTION
`pgrep` (at least on my system) is painfully slow at searching through the pid list. It leads to noticeable latency when using jump app (so bad that I was tempted to just use raw wmctrl instead since it's nearly instantaneous).

Before the patch:

```
% time ./jumpapp firefox-esr

real	0m0.157s
user	0m0.132s
sys	0m0.029s
```

After applying the patch:

```
% time ./jumpapp firefox-esr

real	0m0.038s
user	0m0.033s
sys	0m0.010s
```

I'm using `pgrep` from procps 2:3.3.16-5 (i.e. devuan unstable latest) and it dwarfs the total execution time of the jumpapp script:

```
% time pgrep -f firefox-esr
1319
1370
1552
1594
2740
2797
5187
5676
29371

real	0m0.116s
user	0m0.112s
sys	0m0.004s
```

I'm pretty sure procfs is standard across most distributions, and since it's notably faster (a little more than 4x faster), I think the it's a better approach. However, if you want to maintain maximum portability through with the inclusion of `pgrep` I'd suggest using it as the fallback rather than procfs since it's slower.