### PR TITLE
try _NET_CLIENT_LIST if _NET_CLIENT_LIST_STACKING doesn't work

### DIFF
--- a/jumpapp
+++ b/jumpapp
@@ -379,7 +379,7 @@ get_active_windowid() {
 list_stacking_order() {
     local name ids
     read -r name ids < <(xprop -root ' $0+\n' _NET_CLIENT_LIST_STACKING)
-    if [[ "$ids" == 'not found.' ]]; then
+    if [[ "$ids" == 'not found.' ]] || [[ "$ids" =~ 'no such atom' ]]; then
         # in case the window manager doesn't support _NET_CLIENT_LIST_STACKING (p.e. dwm)
         read -r name ids < <(xprop -root ' $0+\n' _NET_CLIENT_LIST)
     fi

--- a/jumpapp
+++ b/jumpapp
@@ -379,6 +379,10 @@ get_active_windowid() {
 list_stacking_order() {
     local name ids
     read -r name ids < <(xprop -root ' $0+\n' _NET_CLIENT_LIST_STACKING)
+    if [[ "$ids" == 'not found.' ]]; then
+        # in case the window manager doesn't support _NET_CLIENT_LIST_STACKING (p.e. dwm)
+        read -r name ids < <(xprop -root ' $0+\n' _NET_CLIENT_LIST)
+    fi
     printf '%s\n' "$ids" | tr ',' ' '
 }
 


### PR DESCRIPTION
In window managers that don't support _NET_CLIENT_LIST_STACKING (dwm), jumpapp emit this error message:


    /usr/bin/jumpapp: line 248: [[: found.: syntax error: invalid arithmetic operator (error token is ".")

With this PR, jumpapp queries _NET_CLIENT_LIST when _NET_CLIENT_LIST_STACKING doesn't contain any values. This fixes #54 in a sense that this error message doesn't occur anymore.

But it still doesn't work as expected. When you run `jumpapp firefox`:

* ✔ start firefox when it's not yet running
* ✔ jump to firefox when another program is active
* ✔ jump to second firefox window when first firefox window is active
* ✘ jump to the most recent firefox window (when there are more than one), coming from another program

When firefox is not active, jumpapp brings you always to the firefox window created first. (Without this PR, the firefox window created last.) Maybe dwm doesn't update _NET_CLIENT_LIST. Nevertheless, I think this PR brings an improvement to dwm users.