### PR TITLE
Add fallback to WM_NAME

### DIFF
--- a/jumpapp
+++ b/jumpapp
@@ -366,6 +366,7 @@ list_pids_for_command_from_procfs() {
 list_windows() {
     local windowid workspace pid wm_class hostname title
     while read -r windowid workspace pid wm_class hostname title; do
+        [[ "$title" == "N/A" ]] && title=$(xprop -id $windowid WM_NAME)
         printf '%s\n' "$windowid $hostname $pid $workspace ${wm_class##*.} $title"
     done < <(wmctrl -lpx)
 }


### PR DESCRIPTION
`wmctrl` only reads `_NET_WM_NAME`, however some applications (e.g. steam) do not set it and only set `WM_NAME`.

When `_NET_WM_NAME` is missing, `wmctrl` gives the name as `N/A`; in such a case there is a chance we can still get the right name from `WM_NAME`.

Fixes https://github.com/mkropat/jumpapp/issues/75