### PR TITLE
Makefile can be used with GNU and BSD make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ FILES	= t README.md LICENSE.txt Makefile jumpapp jumpappify-desktop-entry
 all: jumpapp.1
 
 jumpapp.1: README.man.md
-	@hash pandoc 2>/dev/null || { echo "ERROR: can't find pandoc. Have you installed it?" >&2; exit 1; }
-	pandoc --from=markdown --standalone --output="$@" "$<"
+	@which pandoc 2>/dev/null || { echo "ERROR: can't find pandoc. Have you installed it?" >&2; exit 1; }
+	pandoc --from=markdown --standalone --output=$@ README.man.md
 
 README.man.md: README.md
 	echo '% JUMPAPP(1) jumpapp | $(VERSION)' >"$@"


### PR DESCRIPTION
Hello here is a small tweak to the Makefile so that it works with both GNU & BSD make. Tested with GNU make 4.4.1 and OpenBSD 7.5 make.