### PR TITLE
Make -m flag imply force launch when no window found

### DIFF
--- a/jumpapp
+++ b/jumpapp
@@ -37,7 +37,7 @@ main() {
             h) show_usage; exit 0 ;;
             i) cmdid="$OPTARG" ;;
             L) list=1 ;;
-            m) focusOrMinimize=1 ;;
+            m) focusOrMinimize=1; force=1 ;;
             n) fork='' ;;
             N) no_launch=1; ;;
             p) passthrough=1; force=1 ;; # passthrough implies force


### PR DESCRIPTION
When an app runs as a persistent daemon (e.g. pcmanfm -d), -m would error with "found running process but no window" instead of launching. -m now implies force=1, consistent with -w, -t, and -p.